### PR TITLE
Hyperlink DOI to preferred resolver

### DIFF
--- a/src/main/kotlin/com/gmail/polikutinevgeny/utility/Utility.kt
+++ b/src/main/kotlin/com/gmail/polikutinevgeny/utility/Utility.kt
@@ -49,7 +49,7 @@ object Constants {
     /**
      * Scale for the temperature gradient.
      *
-     * @see <a href="http://dx.doi.org/10.1002/2017GL073662">
+     * @see <a href="https://doi.org/10.1002/2017GL073662">
      *     A simple diagnostic for the detection of atmospheric fronts<\a>
      *
      * */


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

Cheers!